### PR TITLE
Fix pixel density reference

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -46,7 +46,11 @@ const sketch = (p) => {
 
     p.setup = () => {
         p.createCanvas(p.windowWidth, p.windowHeight, p.WEBGL);
-        p.pixelDensity(p.min(p.devicePixelRatio, 1.5));
+        // Use the browser's devicePixelRatio for crisp rendering,
+        // fallback to 1 if not available. p.devicePixelRatio is undefined
+        // in p5.js and caused pixelDensity to be set to NaN.
+        const dpr = window.devicePixelRatio || 1;
+        p.pixelDensity(p.min(dpr, 1.5));
         p.disableFriendlyErrors = true;
 
         cam = p.createCamera();


### PR DESCRIPTION
## Summary
- fix NaN pixel density calculation by using `window.devicePixelRatio`

## Testing
- `node -c sketch.js`


------
https://chatgpt.com/codex/tasks/task_e_6846ccb8a1188328a299560e1923f68e